### PR TITLE
feat(rename): Support renaming from TypeScript files

### DIFF
--- a/override_rename_ts_plugin/README.md
+++ b/override_rename_ts_plugin/README.md
@@ -1,0 +1,6 @@
+This package is applied to the built-in TS extension by the config [`typescriptServerPlugins`][1] and is used to disable rename provider of the built-in TS extension so VSCode asks the Angular Language Service for the answer instead.
+
+Detail about this package is [here][2].
+
+[1]: https://code.visualstudio.com/api/references/contribution-points#contributes.typescriptServerPlugins
+[2]: https://github.com/angular/angular/blob/master/packages/language-service/README.md#override-rename-ts-plugin

--- a/override_rename_ts_plugin/index.js
+++ b/override_rename_ts_plugin/index.js
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+module.exports = require("@angular/language-service/override_rename_ts_plugin").factory;

--- a/override_rename_ts_plugin/package.json
+++ b/override_rename_ts_plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@angular/override-rename-ts-plugin",
+  "version": "0.0.1",
+  "main": "./index.js",
+  "private": "true"
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coc-angular",
   "description": "Editor services for Angular templates",
-  "version": "13.2.7",
+  "version": "14.0.0-next.0",
   "keywords": [
     "coc.nvim",
     "angular",
@@ -125,7 +125,7 @@
   "dependencies": {
     "v12_language_service": "file:v12_language_service",
     "@angular/override-rename-ts-plugin": "file:override_rename_ts_plugin",
-    "@angular/language-server": "13.2.3",
+    "@angular/language-server": "14.0.0-next.0",
     "typescript": "~4.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,7 +102,13 @@
           "description": "Enable/disable snippet completions from Angular language server. Requires using TypeScript 4.3+ in the workspace and the `legacy View Engine` option to be disabled."
         }
       }
-    }
+    },
+     "typescriptServerPlugins": [
+      {
+        "name": "@angular/override-rename-ts-plugin",
+        "enableForWorkspaceTypeScriptVersions": true
+      }
+     ]
   },
   "scripts": {
     "build": "rm -rf ./out/ && webpack",
@@ -118,6 +124,7 @@
   },
   "dependencies": {
     "v12_language_service": "file:v12_language_service",
+    "@angular/override-rename-ts-plugin": "file:override_rename_ts_plugin",
     "@angular/language-server": "13.2.3",
     "typescript": "~4.4.3"
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -70,16 +70,7 @@ export class AngularLanguageClient implements vscode.Disposable {
          prepareRename: async (
             document: vscode.TextDocument, position: vscode.Position,
             token: vscode.CancellationToken, next: vscode.PrepareRenameSignature) => {
-          // We are able to provide renames for many types of string literals: template strings,
-          // pipe names, and hopefully in the future selectors and input/output aliases. Because
-          // TypeScript isn't able to provide renames for these, we can more or less
-          // guarantee that the Angular Language service will be called for the rename as the
-          // fallback. We specifically do not provide renames outside of string literals
-          // because we cannot ensure our extension is prioritized for renames in TS files (see
-          // https://github.com/microsoft/vscode/issues/115354) we disable renaming completely so we
-          // can provide consistent expectations.
-          if (await this.isInAngularProject(document) &&
-              isInsideStringLiteral(document, position)) {
+          if (await this.isInAngularProject(document)) {
             return next(document, position, token);
           }
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,9 @@
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-13.2.2.tgz#4de8742dc7603a331cb39be065f5a30d0bdc0fad"
   integrity sha512-2P5+wRsbHgpI2rVeFwnsLWxyntUiw8kG9Tqh5BkVDqtQovbYtzFiaMkf5TFz/g938JBBgeRQzvXr1kQhEidAWQ==
 
+"@angular/override-rename-ts-plugin@file:override_rename_ts_plugin":
+  version "0.0.1"
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz#8f03a22a04de437254e8ce8cc84ba39689288752"


### PR DESCRIPTION
This PR will add a new package that is applied to the built-in TS
extension by the config [`typescriptServerPlugins`][1] and is used
to disable rename provider of the built-in TS extension so VSCode
asks the Angular Language Service for the answer instead.

Detail about this package is [here][2].

[1]: https://code.visualstudio.com/api/references/contribution-points#contributes.typescriptServerPlugins
[2]: https://github.com/angular/angular/blob/master/packages/language-service/README.md#override-rename-ts-plugin