### PR TITLE
chore: update to v13.3.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Angular Language Service
 
-> fork from [angular/vscode-ng-language-service](https://github.com/angular/vscode-ng-language-service) v13.3.0
-> [commit](https://github.com/angular/vscode-ng-language-service/commit/45b1d7ea3b57b6bef17f4f418d98d49c1216d488)
+> fork from [angular/vscode-ng-language-service](https://github.com/angular/vscode-ng-language-service) v13.3.2
+> [commit](https://github.com/angular/vscode-ng-language-service/commit/7a2212888132d357493d06110f746f303309a5b1)
 
 An angular language service coc extension for (neo)vim 💖
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coc-angular",
   "description": "Editor services for Angular templates",
-  "version": "13.3.4",
+  "version": "13.3.5",
   "keywords": [
     "coc.nvim",
     "angular",
@@ -118,7 +118,7 @@
   },
   "dependencies": {
     "v12_language_service": "file:v12_language_service",
-    "@angular/language-server": "13.3.0",
+    "@angular/language-server": "13.3.2",
     "typescript": "~4.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,20 +2,20 @@
 # yarn lockfile v1
 
 
-"@angular/language-server@13.3.0":
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/@angular/language-server/-/language-server-13.3.0.tgz#b6b800290646919f723c1fda6ca37bd3d8999680"
-  integrity sha512-XGca8f4DYhQUIIe2v4lO7ZWN8YpkD+htqKhZBJS1blmoMBn0XN6kIPkSD501Xh3hK36Qvf6+z3rIJ+Gh6Hr9Dw==
+"@angular/language-server@13.3.2":
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/@angular/language-server/-/language-server-13.3.2.tgz#00149a021365e3134e6ff43b5a15e4b06854eaf8"
+  integrity sha512-WEQcJLvAfIa4mA4tTifvEEp+4C999ZTghxTAX83gpbfGO9yifpBEaXrro6byc6Y6XBoB9gGOlWY0iGEZo6mRMw==
   dependencies:
-    "@angular/language-service" "13.3.0"
+    "@angular/language-service" "13.3.5"
     vscode-jsonrpc "6.0.0"
     vscode-languageserver "7.0.0"
     vscode-uri "3.0.3"
 
-"@angular/language-service@13.3.0":
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-13.3.0.tgz#366bde21a952ae6ccf2f05659924a583fba01577"
-  integrity sha512-XzfamYk39h+ASxb2ycZKfn9nITmns+jTV+DPrFAY1BoW+4x3tAoqt3/CkdJn8UaCePswKXckDQ6y9i109TfddQ==
+"@angular/language-service@13.3.5":
+  version "13.3.5"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-13.3.5.tgz#c93cc243820fdc96f8289354c9b1791d16cd53f4"
+  integrity sha512-IJawCyu4Zwk6GNPDkbSkY6sFYaBHtaHMwhaiRojrqiKA0n2bDNULLcHfYGSyA7UvkX8m9Nt0M5GaF66BIwuZSw==
 
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.2"


### PR DESCRIPTION
Hey @iamcco 👋 
Please consider this update. As you can see there aren't really any changes to the client beyond updating the server dep.

Release diff: [https://github.com/angular/vscode-ng-language-service/compare/v13.3.0...v13.3.2](https://github.com/angular/vscode-ng-language-service/compare/v13.3.0...v13.3.2)

Thanks.