### PR TITLE
chore: update to v13.3.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Angular Language Service
 
-> fork from [angular/vscode-ng-language-service](https://github.com/angular/vscode-ng-language-service) v13.3.2
-> [commit](https://github.com/angular/vscode-ng-language-service/commit/7a2212888132d357493d06110f746f303309a5b1)
+> fork from [angular/vscode-ng-language-service](https://github.com/angular/vscode-ng-language-service) v13.3.4
+> [commit](https://github.com/angular/vscode-ng-language-service/commit/6d1a664e05ec569d96afdcfc871acb176e8ff846)
 
 An angular language service coc extension for (neo)vim 💖
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coc-angular",
   "description": "Editor services for Angular templates",
-  "version": "13.3.8",
+  "version": "13.3.4",
   "keywords": [
     "coc.nvim",
     "angular",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coc-angular",
   "description": "Editor services for Angular templates",
-  "version": "13.3.4",
+  "version": "13.3.6",
   "keywords": [
     "coc.nvim",
     "angular",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coc-angular",
   "description": "Editor services for Angular templates",
-  "version": "13.3.5",
+  "version": "13.3.8",
   "keywords": [
     "coc.nvim",
     "angular",
@@ -118,7 +118,7 @@
   },
   "dependencies": {
     "v12_language_service": "file:v12_language_service",
-    "@angular/language-server": "13.3.2",
+    "@angular/language-server": "13.3.4",
     "typescript": "~4.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,20 +2,20 @@
 # yarn lockfile v1
 
 
-"@angular/language-server@13.3.2":
-  version "13.3.2"
-  resolved "https://registry.yarnpkg.com/@angular/language-server/-/language-server-13.3.2.tgz#00149a021365e3134e6ff43b5a15e4b06854eaf8"
-  integrity sha512-WEQcJLvAfIa4mA4tTifvEEp+4C999ZTghxTAX83gpbfGO9yifpBEaXrro6byc6Y6XBoB9gGOlWY0iGEZo6mRMw==
+"@angular/language-server@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@angular/language-server/-/language-server-13.3.4.tgz#0560762fd15a86d5800473505d5ac02ade78725d"
+  integrity sha512-9I6h66TPAY3CbKkBtsj5XAlfJhhexD1KSy7gfe2ZXQsrXygCj6BvjaaDGK5DKs2ea/LLtIDKGb9GAlrJL3dnrw==
   dependencies:
-    "@angular/language-service" "13.3.5"
+    "@angular/language-service" "13.3.8"
     vscode-jsonrpc "6.0.0"
     vscode-languageserver "7.0.0"
     vscode-uri "3.0.3"
 
-"@angular/language-service@13.3.5":
-  version "13.3.5"
-  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-13.3.5.tgz#c93cc243820fdc96f8289354c9b1791d16cd53f4"
-  integrity sha512-IJawCyu4Zwk6GNPDkbSkY6sFYaBHtaHMwhaiRojrqiKA0n2bDNULLcHfYGSyA7UvkX8m9Nt0M5GaF66BIwuZSw==
+"@angular/language-service@13.3.8":
+  version "13.3.8"
+  resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-13.3.8.tgz#82b5769f9176b0955f2bd0bf2dde8f7e6d24560a"
+  integrity sha512-dA+uxtUO+7i5gMCwIMtaUMse6+Bep6JcDWo8GJ/nWS8c3GAS2E96Sm3NBycKWGaiz9HNOgO2cbpPlMifKPREow==
 
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.2"


### PR DESCRIPTION
Hi @iamcco 

First of all, thank you for this repo! 

Please consider this update. It's just dependencies update.

Release diff: https://github.com/angular/vscode-ng-language-service/compare/v13.3.2...v13.3.4

IMPORTANT

In this [commit](https://github.com/iamcco/coc-angular/pull/57/commits/49d9f985c2354ab64aaceca570e6216edc924491) I have changed `coc-angular` version back to v13.3.4 from v13.3.5, so it would in sync with [v13.3.4 release version](https://github.com/angular/vscode-ng-language-service/commit/6d1a664e05ec569d96afdcfc871acb176e8ff846) of vscode-ng-language-service