### PR TITLE
fix(ft): add htmlangular filetype to support newer nvim versions

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -51,6 +51,7 @@ export class AngularLanguageClient implements vscode.Disposable {
         // scheme: 'file' means listen to changes to files on disk only
         // other option is 'untitled', for buffer in the editor (like a new doc)
         {scheme: 'file', language: 'html'},
+        {scheme: 'file', language: 'htmlangular'},
         {scheme: 'file', language: 'typescript'},
       ],
       synchronize: {


### PR DESCRIPTION
Neovim now detects the angular component files and sets `htmlangular` as the filetype. This caused coc-angular to not be loaded in the template files as it looked for the 'html' filetype.

Retaining 'html' as well supports both older and newer configs.

Fixes #78 